### PR TITLE
Adding JSON file type to provide quote-cycling

### DIFF
--- a/src/es-quotes.ts
+++ b/src/es-quotes.ts
@@ -22,6 +22,7 @@ export const enum StringType {
 const supportedLanguages = [
     'javascript',
     'javascriptreact',
+    'json',
     'typescript',
     'typescriptreact',
     'vue'


### PR DESCRIPTION
When getting sample JSON from different sources that may or may not render clean JSON, the quote-cycling feature is priceless.